### PR TITLE
Fix: Preserve record player state when navigating to collection

### DIFF
--- a/src/components/FeaturedProjects.tsx
+++ b/src/components/FeaturedProjects.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { ExternalLink } from "./shared/ExternalLink";
 import { Section } from "./shared/Section";
 import { SectionTitle } from "./shared/SectionTitle";
@@ -26,12 +27,12 @@ export default function FeaturedProjects() {
           An intermediary web API to serve information from the official Discogs
           API from a cached source to avoid rate limiting. Currently powering
           the{" "}
-          <a
+          <Link
             href="/collection"
             className="text-emerald-600 hover:text-emerald-700 transition-colors duration-200 underline decoration-emerald-600/30 hover:decoration-emerald-700/50"
           >
             My Records
-          </a>{" "}
+          </Link>{" "}
           page of this site! Authentication key required for API calls.
         </>
       ),


### PR DESCRIPTION
## Summary
- Replace standard anchor tag with Next.js Link component in FeaturedProjects
- Enables client-side navigation to preserve RecordPlayerContext state

## Test plan
- [x] Start playing a record on the home or collection page
- [x] Navigate to portfolio page
- [x] Click "My Records" link in the Discogs Collection API project card
- [x] Verify music continues playing and record animation persists

Fixes #21